### PR TITLE
Replace jsdom with cheerio

### DIFF
--- a/html-extract.js
+++ b/html-extract.js
@@ -34,7 +34,7 @@ module.exports = function(opts) {
       [].forEach.call(els, function(el, i) {
         self.push(new gutil.File({
           // Name: id or tag + index.
-          path: file.path + "-" + (el.id || el.tagName + "-" + i),
+          path: file.path + "-" + (el.attribs.id || el.tagName + "-" + i),
           contents: new Buffer(el.children[0].data)
         }));
       });

--- a/html-extract.js
+++ b/html-extract.js
@@ -22,6 +22,7 @@ module.exports = function(opts) {
   var stream = through2.obj(function(file, enc, callback) {
     var self = this;
     var contentExtracted;
+    var els;
 
     if (file.isStream()) {
       return stream.emit("error",
@@ -30,7 +31,7 @@ module.exports = function(opts) {
 
     if (file.isBuffer()) {
       contentExtracted = cheerio.load(file.contents.toString("utf8"));
-      var els = contentExtracted(sel);
+      els = contentExtracted(sel);
       [].forEach.call(els, function(el, i) {
         self.push(new gutil.File({
           // Name: id or tag + index.

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "url": "https://github.com/FormidableLabs/gulp-html-extract/issues"
   },
   "dependencies": {
-    "through2": "0.4.1",
+    "cheerio": "^0.19.0",
     "gulp-util": "2.2.14",
-    "jsdom": "0.10.5"
+    "through2": "0.4.1"
   },
   "devDependencies": {
     "gulp-jshint": "1.5.5",


### PR DESCRIPTION
Due to [problems to use `jsdom` package in Windows systems](https://github.com/FormidableLabs/gulp-html-extract/issues/2), I replace it with `cheerio` package. 

This is a screenshot of the test results running under Windows:

![captura](https://cloud.githubusercontent.com/assets/997038/9768953/5f79e0ae-5727-11e5-9e55-fd1201c42f78.jpg)
