### PR TITLE
Fix when the element has no children

### DIFF
--- a/test/html-extract.spec.js
+++ b/test/html-extract.spec.js
@@ -54,7 +54,7 @@ describe("html-extract", function () {
       })
       .on("end", function () {
         expect(err).to.not.be.ok;
-        expect(count).to.equal(2);
+        expect(count).to.equal(3);
         done(err);
       })
       .end(this.file);

--- a/test/test.html
+++ b/test/test.html
@@ -16,5 +16,14 @@
         SECOND_TEXT
       </textarea>
     </p>
+    <div>
+    <!--
+    Lorem ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing
+    -->
+    <script>
+      var foo = "bar";
+    </script>
+    </div>
+    <script src="foobar/foobar.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Hi, I've discovered a bug when the task reads an element without children. For example, a script tag that links  to a JavaScript file inside the document: `<script src="foobar/foobar.js"></script>`. In this case the current version of the task throws an error. 

I've added new tests to resolve this sceneario.

By the way, the name of the branch is different because when I discovered this bug, I thought that it was related with the comments.

Regards.
