### PR TITLE
Trim whitespace

### DIFF
--- a/html-extract.js
+++ b/html-extract.js
@@ -5,6 +5,7 @@ var cheerio = require("cheerio"),
   gutil = require("gulp-util"),
   PluginError = gutil.PluginError,
   through2 = require("through2"),
+  trim = require("trim"),
   PLUGIN_NAME = "html-text";
 
 /**
@@ -41,7 +42,7 @@ module.exports = function (opts) {
           self.push(new gutil.File({
             // Name: id or tag + index.
             path: file.path + "-" + (el.attribs.id || el.tagName + "-" + i),
-            contents: new Buffer(el.children[0].data)
+            contents: new Buffer(trim.left(el.children[0].data))
           }));
         }
       });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "cheerio": "^0.19.0",
     "gulp-util": "2.2.14",
-    "through2": "0.4.1"
+    "through2": "0.4.1",
+    "trim": "0.0.1"
   },
   "devDependencies": {
     "gulp-jshint": "1.5.5",


### PR DESCRIPTION
We're using `gulp-html-extract` in [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit) but noticed that the extracted js leaves in all indentation from the html document, causing JSHint's `indent` rules to always fail. This PR attempts to fix that by stripping out all whitespace on the left-hand side. Hopefully this still preserves any trailing whitespace on the right which would be an actual JSHint error.
