### PR TITLE
Add options.pad

### DIFF
--- a/html-extract.js
+++ b/html-extract.js
@@ -57,8 +57,8 @@ module.exports = function (opts) {
 
           // Pad the file content with the corresponding top empty lines if specified
           if (pad) {
-            var topText = fileContent.slice(0, el.startIndex + 1);
-            var numTopLines = (topText.match(/\r?\n/g) || []).length;
+            var topText = fileContent.slice(0, el.startIndex);
+            var numTopLines = (topText.match(/\r?\n/g) || []).length + 1;
             var emptyTopLines = new Array(numTopLines).join("\n");
 
             data = emptyTopLines + data;


### PR DESCRIPTION
Related to #9.

When piping the extracted content to jshint, eslint or whatever, the reporter references line numbers that, obviously, do not match the line in the original (physical) source file.

The new `options.pad` (if set to `true`) prepends empty lines to the extracted content so line numbers will match the values in the original file.
